### PR TITLE
[7] Correct the YAML arguments for passing to the appclient and the s…

### DIFF
--- a/modules/com.sun.ts-module.xml
+++ b/modules/com.sun.ts-module.xml
@@ -8,6 +8,7 @@
         <resource-root path="jboss-porting.jar"/>
         <resource-root path="tsharness.jar"/>
         <resource-root path="whitebox.jar"/>
+        <resource-root path="common.jar"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,31 @@
                 </configuration>
             </plugin>
 
+            <!-- Temporary hack to include the common TCK library in com.sun.ts module -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-common-lib-to-module</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>common</artifactId>
+                                    <version>${version.jakarta.tck}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${jboss.home}/modules/system/layers/base/com/sun/ts/main/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/test/resources/javatest-appclient-arquillian.xml
+++ b/src/test/resources/javatest-appclient-arquillian.xml
@@ -37,7 +37,7 @@
             <property name="runClient">true</property>
             <property name="runAsVehicle">true</property>
             <property name="clientEarDir">target/appclient</property>
-            <property name="clientCmdLineString">${jboss.home}/bin/appclient.sh;-y;${project.build.testOutputDirectory}/appclient.yml;-y;${project.build.testOutputDirectory}/derby.yml;${clientEarDir}/${vehicleArchiveName}.ear#${vehicleArchiveName}_client.jar</property>
+            <property name="clientCmdLineString">${jboss.home}/bin/appclient.sh;-y=${project.build.testOutputDirectory}/appclient.yml:${project.build.testOutputDirectory}/derby.yml;${clientEarDir}/${vehicleArchiveName}.ear#${vehicleArchiveName}_client.jar</property>
             <property name="clientEnvString">MY_EN=my-env-stting</property>
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">${ts.home}/tmp</property>

--- a/src/test/resources/javatest-arquillian.xml
+++ b/src/test/resources/javatest-arquillian.xml
@@ -28,7 +28,7 @@
     <container qualifier="tck-javatest" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="jbossArguments">-y=${project.build.testOutputDirectory}/wildfly-tck-min.yml -y=${project.build.testOutputDirectory}/derby.yml</property>
+            <property name="jbossArguments">-y=${project.build.testOutputDirectory}/wildfly-tck-min.yml:${project.build.testOutputDirectory}/derby.yml</property>
             <!--property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.ts</property-->
             <property name="javaVmArguments"><!-- -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y --></property>
             <property name="serverConfig">${wildfly.standalone.config}</property>


### PR DESCRIPTION
…erver. Add the jakarta.tck:common library to the module for the appclient.

resolves #7 

Note I think we need to change the way we create the module, but this should get us passing the JMS tests now.